### PR TITLE
fix: allowed emails, staff dashboard categories on the dropdown, supabase auth persistance

### DIFF
--- a/apps/web/src/app/auth/register/page.tsx
+++ b/apps/web/src/app/auth/register/page.tsx
@@ -65,7 +65,7 @@ export default function RegisterPage() {
     if (!formData.email || !formData.email.includes("@"))
       return "Please enter a valid email address";
     if (
-      !formData.email.endsWith("@mynwu.ac.za") ||
+      !formData.email.endsWith("@mynwu.ac.za") &&
       !formData.email.endsWith("@nwu.ac.za")
     )
       return "Please use your university email (@mynwu.ac.za)";

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -238,11 +238,10 @@ const MenuItemForm: React.FC<MenuItemFormProps> = ({
           className="w-full mt-1 p-2 border rounded-md dark:bg-gray-800 dark:text-white"
         >
           <option value="">Select a category</option>
-          <option value="Traditional">Traditional</option>
-          <option value="Grill">Grill</option>
-          <option value="Sandwhich">Sandwhich</option>
-          <option value="Beverages">Beverages</option>
-          <option value="Beverages">Other</option>
+          {availableCategories.map((category) => (
+            <option value={category}>{category}</option>
+          ))}
+          <option value="Other">Other</option>
         </select>
       </div>
       <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-md">
@@ -426,7 +425,7 @@ const AddMenuItemModal: React.FC<AddMenuItemModalProps> = ({
       <MenuItemForm
         onSubmit={handleSubmit}
         isSubmitting={isSubmitting}
-        availableCategories={[]}
+        availableCategories={availableCategories}
       />
     </Modal>
   );
@@ -525,7 +524,15 @@ const MenuManagement: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const availableCategories = ["Traditional", "Grill", "Sandwich", "Beverages"];
+  const availableCategories = [
+    "Panini",
+    "Decadent",
+    "Sandwich",
+    "Beverages",
+    "Burgers",
+    "Wraps",
+    "Add-on",
+  ];
   const [deletingItemId, setDeletingItemId] = useState<string | null>(null);
 
   // Mock API Call (Replace with actual fetch logic)

--- a/apps/web/src/components/AuthSyncProvider.tsx
+++ b/apps/web/src/components/AuthSyncProvider.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+import { TOKEN_STORAGE_KEY } from "@/lib/auth";
+
+export default function AuthSyncProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    // Listen for token refresh, sign-in, sign-out, etc.
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        if (session?.access_token) {
+          localStorage.setItem(TOKEN_STORAGE_KEY, session.access_token);
+        } else {
+          localStorage.removeItem(TOKEN_STORAGE_KEY);
+        }
+      }
+    );
+
+    return () => {
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -4,21 +4,24 @@ import { ThemeProvider } from "./theme-provider";
 import { Toaster } from "./ui/sonner";
 import { CartProvider } from "../context/CartContext";
 import { AppProgressProvider as ProgressProvider } from "@bprogress/next";
+import AuthSyncProvider from "./AuthSyncProvider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider
-      attribute="class"
-      defaultTheme="system"
-      enableSystem
-      disableTransitionOnChange
-    >
-      <ProgressProvider>
-        <CartProvider>
-          {children}
-          <Toaster richColors />
-        </CartProvider>
-      </ProgressProvider>
-    </ThemeProvider>
+    <AuthSyncProvider>
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        disableTransitionOnChange
+      >
+        <ProgressProvider>
+          <CartProvider>
+            {children}
+            <Toaster richColors />
+          </CartProvider>
+        </ProgressProvider>
+      </ThemeProvider>
+    </AuthSyncProvider>
   );
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -72,3 +72,17 @@ export const clearAuth = (storage?:any): void => {
 export const isAuthenticated = (): boolean => {
   return getAuthStatus() && getUserData() !== null && getAccessToken() !== null;
 };
+
+export const isTokenExpired = (): boolean => {
+  const token = getAccessToken();
+  if (!token) return true;
+
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    const expiry = payload.exp * 1000; // convert to ms
+    return Date.now() > expiry;
+  } catch (err) {
+    console.error('Invalid token format:', err);
+    return true; // treat as expired
+  }
+};


### PR DESCRIPTION
- Fixed the allowed emails on the registration page, to allow @nwu.ac.za and the @mynwu.ac.za, there was a logical operator error where `if email does not end with @nwu.ac.za or does not end with @mynwu.ac.za, show error` was used insteadm and the correct logic was supposed to be `if email does not end with @nwu.ac.za and does not end with @mynwu.ac.za, then show error`
- In the staff dashboard component, the categories on the dropdown were hardcoded, and there are a lot of line in the file, I saw multiple `availableCategories` arrays, but none was used.
- Tried to make the supabase client on the frontend to sync well with the backend, by refreshing the access_token while the user is still on the page.